### PR TITLE
Add Chef 14 and Bionic 18.04 Compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,6 +34,12 @@ platforms:
     attributes:
       apt:
         compile_time_update: true
+  - name: ubuntu-18.04
+    run_list:
+    - recipe[apt]
+    attributes:
+      apt:
+        compile_time_update: true
   - name: debian-7.8
     run_list:
     - recipe[apt]
@@ -59,7 +65,7 @@ suites:
     driver:
       vm_hostname: mongo3
     run_list:
-      - recipe[mongodb3::default]
+      - recipe[socrata-mongodb3-fork::default]
     attributes:
       chef_client:
         config:
@@ -242,7 +248,7 @@ suites:
       vm_hostname: mongo3
     run_list:
       - recipe[mongodb3-test::amazon]
-      - recipe[mongodb3::default]
+      - recipe[socrata-mongodb3-fork::default]
     attributes:
       chef_client:
         config:

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,13 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 4.0.1'
-gem 'test-kitchen', '~> 1.4.0'
-gem 'foodcritic', '4.0.0'
+gem 'berkshelf'
+gem 'test-kitchen'
+gem 'foodcritic'
 
 group :integration do
   gem 'kitchen-vagrant', '~> 0.18.0'
 end
 
 group :test do
-  gem 'chef', '11.10'
   gem 'rspec', '~> 3.1'
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 #
 
 # MongoDB version to install
-default['mongodb3']['version'] = '3.2.8'
+default['mongodb3']['version'] = '4.0.3'
 
 # Please note : The default values for ['mongodb3']['package'] attributes will be set in `package_repo` recipe.
 # but, You can set custom values for yum/apt repo url, yum package version or apt related in your wrapper

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sysadmin@socrata.com'
 license          'Apache 2.0'
 description      'Installs/Configures mongodb3'
 long_description 'Installs/Configures mongodb3'
-version          '999.0.1'
+version          '999.1.0'
 
 supports 'ubuntu', '>= 12.04'
 supports 'debian', '= 7.8'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,7 @@ install_package.each do |pkg|
     case node['platform_family']
       when 'debian'
         # bypass dpkg errors about pre-existing init or conf file
-        options '-o Dpkg::Options::="--force-confold" --force-yes'
+        options '-o Dpkg::Options::="--force-confold"'
     end
     action :install
   end

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -72,7 +72,7 @@ if node['platform'] == 'oracle'
     action :create
   end
   # Set `['runit']['prefer_local_yum'] = true` to avoid install yum repository through packagecloud cookbook
-  node.set['runit']['prefer_local_yum'] = true
+  node.default['runit']['prefer_local_yum'] = true
 end
 
 # Install runit service package through runit::default recipe

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -53,34 +53,38 @@ end
 
 # MongoDB package version to install
 if node['mongodb3']['package']['version'].nil?
-  node.set['mongodb3']['package']['version'] = pkg_version
+  node.default['mongodb3']['package']['version'] = pkg_version
 end
 
 # MongoDB package repo url
 if node['mongodb3']['package']['repo']['url'].nil?
-  node.set['mongodb3']['package']['repo']['url'] = pkg_repo
+  node.default['mongodb3']['package']['repo']['url'] = pkg_repo
 end
 
 # MongoDB repository name
 if node['mongodb3']['package']['repo']['apt']['name'].nil?
-  node.set['mongodb3']['package']['repo']['apt']['name'] = pkg_major_version.to_s
+  node.default['mongodb3']['package']['repo']['apt']['name'] = pkg_major_version.to_s
 end
 
 # MongoDB apt keyserver and key
 if node['mongodb3']['package']['repo']['apt']['keyserver'].nil?
-  node.set['mongodb3']['package']['repo']['apt']['keyserver'] = apt_repo_keyserver
+  node.default['mongodb3']['package']['repo']['apt']['keyserver'] = apt_repo_keyserver
 end
 
 if node['mongodb3']['package']['repo']['apt']['key'].nil?
-  if pkg_major_version >= 3.2
-    node.set['mongodb3']['package']['repo']['apt']['key'] = 'EA312927'
+  if pkg_major_version >= 3.2 && pkg_major_version < 3.6
+    node.default['mongodb3']['package']['repo']['apt']['key'] = 'EA312927'
+  elsif pkg_major_version >= 3.6 && pkg_major_version < 4
+    node.default['mongodb3']['package']['repo']['apt']['key'] = '58712A2291FA4AD5'
+  elsif pkg_major_version >= 4
+    node.default['mongodb3']['package']['repo']['apt']['key'] = '68818C72E52529D4'
   else
-    node.set['mongodb3']['package']['repo']['apt']['key'] = '7F0CEB10'
+    node.default['mongodb3']['package']['repo']['apt']['key'] = '7F0CEB10'
   end
 end
 
 if node['mongodb3']['package']['repo']['apt']['components'].nil?
-  node.set['mongodb3']['package']['repo']['apt']['components'] = apt_repo_component
+  node.default['mongodb3']['package']['repo']['apt']['components'] = apt_repo_component
 end
 
 # Add the MongoDB Package repository

--- a/test/cookbooks/mongodb3-test/metadata.rb
+++ b/test/cookbooks/mongodb3-test/metadata.rb
@@ -6,4 +6,4 @@ description      'Installs/Configures mongodb3-test'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
-depends 'mongodb3'
+depends 'socrata-mongodb3-fork'

--- a/test/cookbooks/mongodb3-test/recipes/custom.rb
+++ b/test/cookbooks/mongodb3-test/recipes/custom.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-node.set['mongodb3']['config']['mongod']['storage']['dbPath'] = '/var/lib/mongodb/custom'
-node.set['mongodb3']['config']['mongod']['systemLog']['path'] = '/var/log/mongodb/custom/mongod.log'
+node.default['mongodb3']['config']['mongod']['storage']['dbPath'] = '/var/lib/mongodb/custom'
+node.default['mongodb3']['config']['mongod']['systemLog']['path'] = '/var/log/mongodb/custom/mongod.log'
 
 include_recipe 'socrata-mongodb3-fork::default'

--- a/test/cookbooks/mongodb3-test/recipes/default-30x.rb
+++ b/test/cookbooks/mongodb3-test/recipes/default-30x.rb
@@ -17,11 +17,11 @@
 # limitations under the License.
 #
 
-node.set['mongodb3']['version'] = '3.0.11'
+node.default['mongodb3']['version'] = '3.0.11'
 
 # For package upgrade testing : executing converge twice with different version
-# node.set['mongodb3']['version'] = '3.2.4'
-# node.set['mongodb3']['package']['version'] = '3.2.4'
-# node.set['mongodb3']['package']['repo']['apt']['name'] = '3.2'
+# node.default['mongodb3']['version'] = '3.2.4'
+# node.default['mongodb3']['package']['version'] = '3.2.4'
+# node.default['mongodb3']['package']['repo']['apt']['name'] = '3.2'
 
 include_recipe 'socrata-mongodb3-fork::default'

--- a/test/cookbooks/mongodb3-test/recipes/mms_automation_agent_with_data_bag.rb
+++ b/test/cookbooks/mongodb3-test/recipes/mms_automation_agent_with_data_bag.rb
@@ -34,7 +34,7 @@
 mms_data_bag_item = Chef::EncryptedDataBagItem.load('mongodb', 'mms-agent')
 mms_data_bag = mms_data_bag_item['environments'][node.chef_environment]
 
-node.set['mongodb3']['config']['mms']['mmsGroupId'] = mms_data_bag['mms_group_id']
-node.set['mongodb3']['config']['mms']['mmsApiKey'] = mms_data_bag['mms_api_key']
+node.default['mongodb3']['config']['mms']['mmsGroupId'] = mms_data_bag['mms_group_id']
+node.default['mongodb3']['config']['mms']['mmsApiKey'] = mms_data_bag['mms_api_key']
 
 include_recipe 'socrata-mongodb3-fork::mms_automation_agent'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -76,5 +76,5 @@ end
 
 # Test mongod process starts with expected mongodb config file
 describe command('export LC_ALL="en_US.UTF-8"; mongo --eval "db.version()"') do
-  its(:stdout) { should contain('3.2.8') }
+  its(:stdout) { should contain('4.0.3') }
 end


### PR DESCRIPTION
This adds support for Ubuntu Bionic 18.04 support along with fixing any
deprecated methods.  The build appears to succeed in tests.

* Changed `node.set` to `node.default`
* Added 18.04 support in kitchen
* Updated default mongodb version to `4.0.3`
* Added logic to handle apt key support on other packages and OS's.

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] CHANGELOG has been updated
- [x] Version has been bumped in metadata
- [x] Commits have been squashed, as appropriate
- [x] Commits include descriptive messages, subjects written in the imperative
